### PR TITLE
Add Tonga, Cook Islands and Nieu

### DIFF
--- a/src/assets/data/countries.csv
+++ b/src/assets/data/countries.csv
@@ -186,7 +186,7 @@ id,name,tag
 426,Lesotho,Lesothian
 140,Central African Republic,Central African
 728,South Sudan,South Sudanese
-384,Cote d'Ivoir,Ivorian
+384,Cote d'Ivoire,Ivorian
 678,Sao Tome and Principe,Sao Tomean
 226,Equatorial Guinea,Equatoguinean
 304,Greenland,Greenlandic

--- a/src/assets/data/countries.csv
+++ b/src/assets/data/countries.csv
@@ -161,6 +161,7 @@ id,name,tag
 756,Switzerland,Swiss
 760,Syria,Syrian
 762,Tajikistan,Tajik
+776,Tonga,Tongan
 834,Tanzania,Tanzanian
 608,Philippines,Philippine
 764,Thailand,Thai

--- a/src/assets/data/countries.csv
+++ b/src/assets/data/countries.csv
@@ -156,7 +156,7 @@ id,name,tag
 882,Samoa,Samoan
 729,Sudan,Sudanese
 740,Suriname,Surinamese
-748,Swaziland,Swazi
+748,Eswatini,Swazi
 752,Sweden,Swedish
 756,Switzerland,Swiss
 760,Syria,Syrian

--- a/src/assets/data/countries.csv
+++ b/src/assets/data/countries.csv
@@ -38,6 +38,7 @@ id,name,tag
 174,Comoros,Comoran
 178,Congo-Brazzaville,Congolese
 180,DR Congo,Congolese
+184,Cook Islands,Cook Islander
 188,Costa Rica,Costa Rican
 192,Cuba,Cuban
 196,Cyprus,Cypriot
@@ -118,6 +119,7 @@ id,name,tag
 562,Niger,Nigerien
 566,Nigeria,Nigerian
 408,North Korea,North Korean
+570,Niue,Niuean
 578,Norway,Norwegian
 840,United States,American
 498,Moldova,Moldovan

--- a/src/assets/js/map.js
+++ b/src/assets/js/map.js
@@ -64,7 +64,7 @@ var countryScore = 0;
 
 
   function updateProgressBar() {
-    var progressPro = (countryScore / 207);
+    var progressPro = (countryScore / 210);
     return progressPro;
   }
 ;
@@ -317,7 +317,7 @@ var countryScore = 0;
       .on("mouseout", function() {
         d3.select("#progress-text").transition().duration(150).style("opacity", 0);
       });
-    d3.select("#progress-text").html("Scrobbled from " + countryScore + "/207 countries")
+    d3.select("#progress-text").html("Scrobbled from " + countryScore + "/210 countries")
 
     //Draw countries
     if (redrawMap) {
@@ -402,9 +402,9 @@ var countryScore = 0;
       }) // on click slutar
 
   }
-  
+
   /*-------redraw----*/
-  //den kallas varje gång datan uppdateras. redrawMap är en boolean 
+  //den kallas varje gång datan uppdateras. redrawMap är en boolean
   function redraw(redrawMap) {
     updateDimensions();
 
@@ -516,7 +516,7 @@ var countryScore = 0;
       .style("opacity", 1)
       .duration(750);
 
-    //Hide progressbar when showing 
+    //Hide progressbar when showing
     d3.selectAll("#countryCount, .on-map-view")
       .classed("hidden", true);
 
@@ -567,7 +567,7 @@ var countryScore = 0;
           eventLabel: 'test'
         });
       }
-  
+
       function showPreviousFive(){
         showArtists(currentNoArtists-9, currentNoArtists-5, false);
         //Trigger GA event
@@ -613,7 +613,7 @@ var countryScore = 0;
                 .attr("class", "image-div")
                 .style("background-image", "url(" + "'" + countryCount[d.id][i].image + "'" + " )")
                 //.append("span").attr("class", "overlayNo").html(i+1);
-                
+
               var playCountDiv = artistDiv.append("div").attr("class", "play-count-div");
 
               playCountDiv.append("p")
@@ -639,7 +639,7 @@ var countryScore = 0;
         //
         //Disable and enable user controls
         //
-        
+
         //Left arrow...
         if (currentNoArtists>=10 && !initial){
           d3.selectAll(".artist-control.left")
@@ -671,11 +671,11 @@ var countryScore = 0;
             });
         }
       }
-      //Fetch the initial five artists!! 
+      //Fetch the initial five artists!!
       showArtists(1, 5, true);
-    
-      
-    } else { //Om landet vi klickat på inte har några lyssnade artister... 
+
+
+    } else { //Om landet vi klickat på inte har några lyssnade artister...
       console.log("landet har inga lyssnade artister");
     }
     //"Recommended"-heading

--- a/src/assets/js/screenshot.js
+++ b/src/assets/js/screenshot.js
@@ -68,7 +68,7 @@ var screenshot = {};
 			ctx.save(); // To draw with different opaticy
 			ctx.globalAlpha = 0.6;
 			ctx.fillStyle = backgroundColor;
-			scoreString = SESSION.total_artists + " artists from " + countryScore + " / 207 countries";
+			scoreString = SESSION.total_artists + " artists from " + countryScore + " / 210 countries";
 			titleString = SESSION.name + "'s musical world map";
 			ctx.font = "34px Patua One";
 			ctx.fillRect(w / 2 - ctx.measureText(titleString).width / 2 - 20, h - 110, ctx.measureText(titleString).width + 40, 100);
@@ -97,7 +97,7 @@ var screenshot = {};
 			// img = document.createElement("img").src = canvas.toDataURL();
 			document.getElementById("screenshot-img").src = canvas.toDataURL("image/png");
 			// d3.select("body").append(img);
-			// 
+			//
 
 			var dataurl = canvas.toDataURL("image/png");
 			// console.log("dataurl:", dataurl)
@@ -105,7 +105,7 @@ var screenshot = {};
 			// window.open(dataurl, "_blank");
 
 			document.getElementsByClassName("screenshot-overlay")[0].style = "";
-			
+
 		}
 		explrLogo.src = "assets/img/explrlogo.png";
 	}


### PR DESCRIPTION
- Adds Tonga, Cook Islands and Nieu. The latter two are both small pacific island countries in free association with New Zealand, but have some recognition in the UN and maintain diplomatic relations under their own name. More importantly they have some music on spotify. :guitar:
- Swaziland changed its name to Eswatini last year
- Cote D'Ivoire had a typo