### PR TITLE
Remove typo-flavoured string in line 1 of the index page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -85,7 +85,7 @@
 						<p class="info">
 						Ever wondered where the artists you listen to come from?</p>
 						<p class="info">
-							Or if there s are any good bands from <span id="randomCountry"></span></p>
+							Or if there are any good bands from <span id="randomCountry"></span></p>
 							
 							<p align="center"><h4>Wonder no more!</h4></p>
 							<p class="info">Enter your Last.fm username in the field below. If you don't have Last.fm, <a href="https://last.fm">get it here!</a></p>


### PR DESCRIPTION
This looks like a typo, and it's right there as the first sentence people read about the project :( 