### PR TITLE
Add audio feedback mode

### DIFF
--- a/src/assets/js/auditory-feedback.js
+++ b/src/assets/js/auditory-feedback.js
@@ -235,9 +235,25 @@ const auditoryFeedback = (function() {
     
     const avgDensity = countries.length > 0 ? totalArtists / countries.length : 0;
     
-    // Normalize density to 0-1 range
-    const maxPossibleAvg = 100; // Adjust based on your data
-    const normalizedDensity = Math.min(avgDensity / maxPossibleAvg, 1);
+    // Get the color domain from the map
+    let normalizedDensity = 0;
+    
+    if (window.map && window.map.getColorDomain) {
+      const colorDomain = window.map.getColorDomain();
+      if (colorDomain && colorDomain.length > 0) {
+        // Find where our density falls in the color domain
+        const maxDomain = colorDomain[colorDomain.length - 1];
+        normalizedDensity = Math.min(avgDensity / maxDomain, 1);
+      } else {
+        // Fallback to old method if color domain isn't available
+        const maxPossibleAvg = 100;
+        normalizedDensity = Math.min(avgDensity / maxPossibleAvg, 1);
+      }
+    } else {
+      // Fallback to old method if map or getColorDomain isn't available
+      const maxPossibleAvg = 100;
+      normalizedDensity = Math.min(avgDensity / maxPossibleAvg, 1);
+    }
     
     // Update the tone
     updateTone(normalizedDensity);

--- a/src/assets/js/auditory-feedback.js
+++ b/src/assets/js/auditory-feedback.js
@@ -1,5 +1,5 @@
 /* 
- * Auditory Feedback Module
+ * Audio Feedback Module
  * Provides audio visualization of artist density on the music map
  * for improved accessibility for blind users
  */
@@ -146,8 +146,8 @@ const auditoryFeedback = (function() {
     if (window.announcer) {
       window.announcer.announce(
         audioFeedbackEnabled ? 
-        "Auditory feedback enabled. Use arrow keys to navigate and hear artist density." : 
-        "Auditory feedback disabled."
+        "Audio feedback enabled. Use arrow keys to navigate and hear artist density for the currently visible countries." : 
+        "Audio feedback disabled."
       );
     }
     

--- a/src/assets/js/auditory-feedback.js
+++ b/src/assets/js/auditory-feedback.js
@@ -1,0 +1,185 @@
+/* 
+ * Auditory Feedback Module
+ * Provides audio visualization of artist density on the music map
+ * for improved accessibility for blind users
+ */
+
+const auditoryFeedback = (function() {
+  // Private variables
+  let audioContext = null;
+  let oscillator = null;
+  let gainNode = null;
+  let audioFeedbackEnabled = false;
+  let keyboardNavigationOnly = true; // Only trigger on keyboard navigation
+  
+  // Initialize Web Audio API
+  function init() {
+    try {
+      // Create audio context with user interaction to avoid autoplay restrictions
+      document.addEventListener('click', function initAudioContext() {
+        if (!audioContext) {
+          audioContext = new (window.AudioContext || window.webkitAudioContext)();
+          console.log("Audio context initialized on user interaction");
+        }
+        document.removeEventListener('click', initAudioContext);
+      }, { once: true });
+      
+      // Add keyboard shortcut for toggling audio feedback
+      document.addEventListener('keydown', function(e) {
+        // Toggle audio feedback with 'A' key
+        if (e.key.toLowerCase() === 'a' && !e.repeat) {
+          toggleAudioFeedback();
+        }
+        
+        // Play feedback on arrow key navigation
+        if (keyboardNavigationOnly && audioFeedbackEnabled && 
+            (e.key === 'ArrowUp' || e.key === 'ArrowDown' || 
+             e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
+          // Small delay to allow the map to update first
+          setTimeout(updateFeedback, 100);
+        }
+      });
+      
+      console.log("Auditory feedback module initialized");
+      
+      // Try to initialize audio context immediately if possible
+      try {
+        audioContext = new (window.AudioContext || window.webkitAudioContext)();
+      } catch (e) {
+        console.log("Audio context will be initialized on first user interaction");
+      }
+    } catch (e) {
+      console.error("Web Audio API is not supported in this browser", e);
+    }
+  }
+  
+  // Toggle audio feedback on/off
+  function toggleAudioFeedback() {
+    audioFeedbackEnabled = !audioFeedbackEnabled;
+    
+    // Announce status change to screen readers
+    if (window.announcer) {
+      window.announcer.announce(
+        audioFeedbackEnabled ? 
+        "Auditory feedback enabled. Use arrow keys to navigate and hear artist density." : 
+        "Auditory feedback disabled."
+      );
+    }
+    
+    if (audioFeedbackEnabled) {
+      // Play initial tone based on current view
+      updateFeedback();
+    }
+  }
+  
+  // Play a tone based on artist density
+  function playDensityTone(density, duration = 300) {
+    if (!audioContext) return;
+    
+    // Stop any currently playing tone
+    if (oscillator) {
+      oscillator.stop();
+      oscillator = null;
+    }
+    
+    // Create new audio nodes
+    oscillator = audioContext.createOscillator();
+    gainNode = audioContext.createGain();
+    
+    // Map density to frequency (pitch)
+    // Low density: 220Hz (low A), High density: 880Hz (high A)
+    const minFreq = 220;
+    const maxFreq = 880;
+    const frequency = minFreq + (density * (maxFreq - minFreq));
+    
+    // Configure oscillator
+    oscillator.type = 'sine'; // Sine wave is less harsh
+    oscillator.frequency.value = frequency;
+    
+    // Configure gain (volume)
+    gainNode.gain.value = 0.1; // Keep volume low to be subtle
+    
+    // Connect nodes
+    oscillator.connect(gainNode);
+    gainNode.connect(audioContext.destination);
+    
+    // Play tone with fade out
+    oscillator.start();
+    console.log("Playing tone with frequency: " + frequency);
+    gainNode.gain.exponentialRampToValueAtTime(0.001, audioContext.currentTime + duration/1000);
+    
+    // Stop after duration
+    setTimeout(() => {
+      if (oscillator) {
+        oscillator.stop();
+        oscillator = null;
+      }
+    }, duration);
+  }
+  
+  // Update auditory feedback based on current map view
+  function updateFeedback() {
+    // Check if feedback is enabled
+    if (!audioFeedbackEnabled) return;
+    
+    // Get the current data from the keyboard mode
+    const countries = getCurrentlyVisibleCountries();
+    if (!countries || countries.length === 0) return;
+    
+    let totalArtists = 0;
+    
+    // Handle different data formats
+    if (Array.isArray(countries) && typeof countries[0] === 'object' && 'artistCount' in countries[0]) {
+      // Format: [{name: "Country", artistCount: 5}, ...]
+      totalArtists = countries.reduce((sum, country) => sum + country.artistCount, 0);
+    } else if (Array.isArray(countries) && typeof countries[0] === 'object' && 'number' in countries[0]) {
+      // Format: [{name: "Country", number: "A", artistCount: 5}, ...]
+      totalArtists = countries.reduce((sum, country) => sum + country.artistCount, 0);
+    } else {
+      // Try to get artist counts from the script data
+      const data = window.script && window.script.getCurrentData ? window.script.getCurrentData() : {};
+      const userName = window.location.href.split("username=")[1];
+      
+      countries.forEach(countryId => {
+        if (data[countryId] && data[countryId][userName]) {
+          totalArtists += data[countryId][userName].length;
+        }
+      });
+    }
+    
+    const avgDensity = countries.length > 0 ? totalArtists / countries.length : 0;
+    
+    // Normalize density to 0-1 range
+    const maxPossibleAvg = 100; // Adjust based on your data
+    const normalizedDensity = Math.min(avgDensity / maxPossibleAvg, 1);
+    
+    // Play tone
+    playDensityTone(normalizedDensity);
+  }
+  
+  // Use the existing function from keyboard-mode.js to get visible countries
+  function getCurrentlyVisibleCountries() {
+    // Try to access it through the keyboardMode object
+    if (window.keyboardMode && typeof window.keyboardMode.getCurrentlyVisibleCountries === 'function') {
+      return window.keyboardMode.getCurrentlyVisibleCountries();
+    }
+    
+    // If we can't find the function, return an empty array
+    console.warn('Could not find getCurrentlyVisibleCountries function');
+    return [];
+  }
+  
+  // Public API
+  return {
+    init: init,
+    updateFeedback: updateFeedback,
+    toggleAudioFeedback: toggleAudioFeedback,
+    isEnabled: function() { return audioFeedbackEnabled; },
+    setKeyboardOnly: function(value) { keyboardNavigationOnly = value; }
+  };
+})();
+
+// Initialize when the DOM is ready
+document.addEventListener('DOMContentLoaded', function() {
+  auditoryFeedback.init();
+}); 

--- a/src/assets/js/auditory-feedback.js
+++ b/src/assets/js/auditory-feedback.js
@@ -11,6 +11,11 @@ const auditoryFeedback = (function() {
   let gainNode = null;
   let audioFeedbackEnabled = false;
   let keyboardNavigationOnly = true; // Only trigger on keyboard navigation
+  let continuousTone = true; // Whether to use a continuous tone that modulates
+  let isPlaying = false; // Track if the tone is currently playing
+  let toneTimeout = null; // Timeout for stopping the tone
+  let toneDuration = 750; // Duration in ms that the tone plays
+  let lastInteractionWasKeyboard = false; // Track if the last interaction was keyboard
   
   // Initialize Web Audio API
   function init() {
@@ -21,6 +26,7 @@ const auditoryFeedback = (function() {
           audioContext = new (window.AudioContext || window.webkitAudioContext)();
           console.log("Audio context initialized on user interaction");
         }
+        lastInteractionWasKeyboard = false; // Mouse click, not keyboard
         document.removeEventListener('click', initAudioContext);
       }, { once: true });
       
@@ -31,13 +37,30 @@ const auditoryFeedback = (function() {
           toggleAudioFeedback();
         }
         
-        // Play feedback on arrow key navigation
-        if (keyboardNavigationOnly && audioFeedbackEnabled && 
-            (e.key === 'ArrowUp' || e.key === 'ArrowDown' || 
-             e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
-          // Small delay to allow the map to update first
-          setTimeout(updateFeedback, 100);
+        // Set flag for keyboard interaction
+        if (e.key === 'ArrowUp' || e.key === 'ArrowDown' || 
+            e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+          lastInteractionWasKeyboard = true;
+          
+          // Play feedback on arrow key navigation
+          if (keyboardNavigationOnly && audioFeedbackEnabled) {
+            // Small delay to allow the map to update first
+            setTimeout(updateFeedback, 100);
+          }
         }
+      });
+      
+      // Track mouse interactions
+      document.addEventListener('mousemove', function() {
+        lastInteractionWasKeyboard = false;
+      });
+      
+      document.addEventListener('mousedown', function() {
+        lastInteractionWasKeyboard = false;
+      });
+      
+      document.addEventListener('wheel', function() {
+        lastInteractionWasKeyboard = false;
       });
       
       console.log("Auditory feedback module initialized");
@@ -51,6 +74,68 @@ const auditoryFeedback = (function() {
     } catch (e) {
       console.error("Web Audio API is not supported in this browser", e);
     }
+  }
+  
+  // Set up the tone audio nodes
+  function setupTone() {
+    if (!audioContext) return;
+    
+    // Clean up any existing oscillator
+    if (oscillator) {
+      try {
+        oscillator.stop();
+      } catch (e) {
+        // Ignore errors if oscillator was already stopped
+      }
+      oscillator = null;
+    }
+    
+    // Create oscillator and gain nodes
+    oscillator = audioContext.createOscillator();
+    gainNode = audioContext.createGain();
+    
+    // Configure oscillator
+    oscillator.type = 'sine'; // Sine wave is less harsh
+    oscillator.frequency.value = 0; // Start at 0 Hz (silent)
+    
+    // Configure gain (volume)
+    gainNode.gain.value = 0; // Start silent
+    
+    // Connect nodes
+    oscillator.connect(gainNode);
+    gainNode.connect(audioContext.destination);
+    
+    // Start the oscillator
+    oscillator.start();
+    isPlaying = true;
+    
+    // Schedule the tone to stop after the duration
+    scheduleToneStop();
+  }
+  
+  // Schedule the tone to stop after the duration
+  function scheduleToneStop() {
+    // Clear any existing timeout
+    if (toneTimeout) {
+      clearTimeout(toneTimeout);
+    }
+    
+    // Set a new timeout to fade out and stop the tone
+    toneTimeout = setTimeout(() => {
+      if (gainNode) {
+        // Fade out
+        gainNode.gain.exponentialRampToValueAtTime(0.001, audioContext.currentTime + 0.5);
+        
+        // Stop oscillator after fade out
+        setTimeout(() => {
+          if (oscillator) {
+            oscillator.stop();
+            oscillator = null;
+            isPlaying = false;
+          }
+        }, 600);
+      }
+    }, toneDuration);
   }
   
   // Toggle audio feedback on/off
@@ -68,23 +153,26 @@ const auditoryFeedback = (function() {
     
     if (audioFeedbackEnabled) {
       // Play initial tone based on current view
+      lastInteractionWasKeyboard = true; // Force keyboard mode for initial tone
       updateFeedback();
+    } else if (gainNode) {
+      // Fade out the tone
+      gainNode.gain.exponentialRampToValueAtTime(0.001, audioContext.currentTime + 0.5);
+      
+      // Clear any scheduled stop
+      if (toneTimeout) {
+        clearTimeout(toneTimeout);
+        toneTimeout = null;
+      }
     }
   }
   
-  // Play a tone based on artist density
-  function playDensityTone(density, duration = 300) {
-    if (!audioContext) return;
+  // Update the tone based on artist density
+  function updateTone(density) {
+    if (!audioContext || !audioFeedbackEnabled) return;
     
-    // Stop any currently playing tone
-    if (oscillator) {
-      oscillator.stop();
-      oscillator = null;
-    }
-    
-    // Create new audio nodes
-    oscillator = audioContext.createOscillator();
-    gainNode = audioContext.createGain();
+    // Skip if keyboard only and last interaction was not keyboard
+    if (keyboardNavigationOnly && !lastInteractionWasKeyboard) return;
     
     // Map density to frequency (pitch)
     // Low density: 220Hz (low A), High density: 880Hz (high A)
@@ -92,35 +180,33 @@ const auditoryFeedback = (function() {
     const maxFreq = 880;
     const frequency = minFreq + (density * (maxFreq - minFreq));
     
-    // Configure oscillator
-    oscillator.type = 'sine'; // Sine wave is less harsh
-    oscillator.frequency.value = frequency;
+    // Create or restart the tone if it's not playing
+    if (!isPlaying) {
+      setupTone();
+    } else {
+      // Extend the duration by rescheduling the stop
+      scheduleToneStop();
+    }
     
-    // Configure gain (volume)
-    gainNode.gain.value = 0.1; // Keep volume low to be subtle
+    // Smoothly change frequency
+    oscillator.frequency.exponentialRampToValueAtTime(
+      frequency, 
+      audioContext.currentTime + 0.2
+    );
     
-    // Connect nodes
-    oscillator.connect(gainNode);
-    gainNode.connect(audioContext.destination);
-    
-    // Play tone with fade out
-    oscillator.start();
-    console.log("Playing tone with frequency: " + frequency);
-    gainNode.gain.exponentialRampToValueAtTime(0.001, audioContext.currentTime + duration/1000);
-    
-    // Stop after duration
-    setTimeout(() => {
-      if (oscillator) {
-        oscillator.stop();
-        oscillator = null;
-      }
-    }, duration);
+    // Fade in if needed
+    if (gainNode.gain.value < 0.1) {
+      gainNode.gain.exponentialRampToValueAtTime(0.1, audioContext.currentTime + 0.1);
+    }
   }
   
   // Update auditory feedback based on current map view
   function updateFeedback() {
     // Check if feedback is enabled
     if (!audioFeedbackEnabled) return;
+    
+    // Skip if keyboard only and last interaction was not keyboard
+    if (keyboardNavigationOnly && !lastInteractionWasKeyboard) return;
     
     // Get the current data from the keyboard mode
     const countries = getCurrentlyVisibleCountries();
@@ -153,8 +239,8 @@ const auditoryFeedback = (function() {
     const maxPossibleAvg = 100; // Adjust based on your data
     const normalizedDensity = Math.min(avgDensity / maxPossibleAvg, 1);
     
-    // Play tone
-    playDensityTone(normalizedDensity);
+    // Update the tone
+    updateTone(normalizedDensity);
   }
   
   // Use the existing function from keyboard-mode.js to get visible countries
@@ -169,13 +255,31 @@ const auditoryFeedback = (function() {
     return [];
   }
   
+  // Clean up resources when the page is unloaded
+  window.addEventListener('beforeunload', function() {
+    if (oscillator) {
+      oscillator.stop();
+      oscillator = null;
+    }
+    
+    if (toneTimeout) {
+      clearTimeout(toneTimeout);
+      toneTimeout = null;
+    }
+  });
+  
   // Public API
   return {
     init: init,
     updateFeedback: updateFeedback,
     toggleAudioFeedback: toggleAudioFeedback,
     isEnabled: function() { return audioFeedbackEnabled; },
-    setKeyboardOnly: function(value) { keyboardNavigationOnly = value; }
+    setKeyboardOnly: function(value) { 
+      keyboardNavigationOnly = value; 
+    },
+    setToneDuration: function(duration) { 
+      toneDuration = duration; 
+    }
   };
 })();
 

--- a/src/assets/js/auditory-feedback.js
+++ b/src/assets/js/auditory-feedback.js
@@ -255,6 +255,30 @@ const auditoryFeedback = (function() {
       });
     }
     
+    // If there are no artists in any of the visible countries, remain silent
+    if (totalArtists === 0) {
+      // Fade out any currently playing tone
+      if (isPlaying && oscillator && gainNode) {
+        gainNode.gain.exponentialRampToValueAtTime(0.001, audioContext.currentTime + 0.5);
+        
+        // Clear any scheduled stop
+        if (toneTimeout) {
+          clearTimeout(toneTimeout);
+          toneTimeout = null;
+        }
+        
+        // Stop oscillator after fade out
+        setTimeout(() => {
+          if (oscillator) {
+            oscillator.stop();
+            oscillator = null;
+            isPlaying = false;
+          }
+        }, 600);
+      }
+      return;
+    }
+    
     const avgDensity = countries.length > 0 ? totalArtists / countries.length : 0;
     
     // Get the color domain from the map

--- a/src/assets/js/keyboard-mode.js
+++ b/src/assets/js/keyboard-mode.js
@@ -377,7 +377,10 @@ function assignLettersToCountries() {
 // Update the announcement functions to only include country count when keyboard mode is active
 function getAnnouncementText(baseText) {
     if (KEYBOARD_MODE_ACTIVE) {
-        return `${baseText}. ${getVisibleCountriesSummary()}`;
+        const audioFeedbackState = window.auditoryFeedback && window.auditoryFeedback.isEnabled() 
+            ? "turn off" 
+            : "turn on";
+        return `${baseText}. ${getVisibleCountriesSummary()}. Press A to ${audioFeedbackState} audio feedback.`;
     }
     return baseText;
 }
@@ -640,7 +643,13 @@ function getAnnouncementText(baseText) {
         window.removeEventListener('keydown', handleLetterKeyPress);        
     }
 
-    keyboardMode.isActive = KEYBOARD_MODE_ACTIVE;
+    keyboardMode.isActive = function() {
+        // Return true if keyboard mode is currently active
+        // Instead of using currentZoomLevel which doesn't exist,
+        // use the stored zoom behavior and check its scale
+        return keyboardMode.zoomBehavior && 
+               keyboardMode.zoomBehavior.scale() >= MIN_ZOOM_LEVEL_FOR_KEYBOARD_MODE;
+    }
 
     keyboardMode.getStatus = function () {
         return KEYBOARD_MODE_ACTIVE;

--- a/src/assets/js/keyboard-mode.js
+++ b/src/assets/js/keyboard-mode.js
@@ -214,13 +214,86 @@ function displayKeyboardModeMessage() {
     const innerMessage = document.createElement("div");
     innerMessage.innerHTML = "<h2>Keyboard mode active! <span class='fa fa-keyboard'></span> </h2><p>Type a <kbd>letter</kbd> to select a country.<p><p>Move around with <kbd>&#8592;</kbd><kbd>&#8594;</kbd><kbd>&#8593;</kbd><kbd>&#8595;</kbd> keys.</p><p>Exit by zooming out with <kbd>-</kbd> key. </p><p>Toggle auditory feedback with <kbd>A</kbd> key.</p>";
     message.appendChild(innerMessage);
-  }
+    
+    // Add the visual indicator for the 400x400 box
+    addViewportBoxIndicator();
+}
 
-    function hideKeyboardModeMessage() {
-        const message = document.getElementById("keyboard-mode-message");
-        message.classList.add("hidden");
-        message.innerHTML = "";
+function hideKeyboardModeMessage() {
+    const message = document.getElementById("keyboard-mode-message");
+    message.classList.add("hidden");
+    message.innerHTML = "";
+    
+    // Remove the visual indicator
+    removeViewportBoxIndicator();
+}
+
+// Add a visual indicator for the 400x400 box used to determine visible countries
+function addViewportBoxIndicator() {
+    // Remove any existing indicator first
+    removeViewportBoxIndicator();
+    
+    // Create the indicator element
+    const indicator = document.createElement("div");
+    indicator.id = "viewport-box-indicator";
+    
+    // Calculate the position and size
+    const rectangleWidth = 400;
+    const rectangleHeight = 400;
+    const rectangleLeft = (window.innerWidth - rectangleWidth) / 2;
+    const rectangleTop = (window.innerHeight - rectangleHeight) / 2;
+    
+    // Set the styles
+    indicator.style.position = "fixed";
+    indicator.style.left = rectangleLeft + "px";
+    indicator.style.top = rectangleTop + "px";
+    indicator.style.width = rectangleWidth + "px";
+    indicator.style.height = rectangleHeight + "px";
+    indicator.style.border = "1px solid rgba(255, 255, 255, 0.6)";
+    indicator.style.pointerEvents = "none"; // Make sure it doesn't interfere with clicks
+    indicator.style.zIndex = "1000"; // Make sure it's above the map but below other UI
+    indicator.style.boxSizing = "border-box";
+    
+    // Add a tooltip/label
+    const label = document.createElement("div");
+    label.textContent = "Active Area";
+    label.style.position = "absolute";
+    label.style.top = "-25px";
+    label.style.left = "50%";
+    label.style.transform = "translateX(-50%)";
+    label.style.backgroundColor = "rgba(0, 0, 0, 0.7)";
+    label.style.color = "white";
+    label.style.padding = "3px 8px";
+    label.style.borderRadius = "3px";
+    label.style.fontSize = "12px";
+    
+    indicator.appendChild(label);
+    document.body.appendChild(indicator);
+    
+    // Update position on window resize
+    window.addEventListener('resize', updateViewportBoxPosition);
+}
+
+function removeViewportBoxIndicator() {
+    const indicator = document.getElementById("viewport-box-indicator");
+    if (indicator) {
+        indicator.remove();
     }
+    window.removeEventListener('resize', updateViewportBoxPosition);
+}
+
+function updateViewportBoxPosition() {
+    const indicator = document.getElementById("viewport-box-indicator");
+    if (indicator) {
+        const rectangleWidth = 400;
+        const rectangleHeight = 400;
+        const rectangleLeft = (window.innerWidth - rectangleWidth) / 2;
+        const rectangleTop = (window.innerHeight - rectangleHeight) / 2;
+        
+        indicator.style.left = rectangleLeft + "px";
+        indicator.style.top = rectangleTop + "px";
+    }
+}
 
 function getPathCenter(path) {
     const y = parseFloat(path.getAttribute("data-center-y"));
@@ -640,7 +713,9 @@ function getAnnouncementText(baseText) {
         document.getElementById("filter").classList.remove("hidden");
         document.querySelector(".no-countries").classList.remove("hidden");
         // remove keyboard listeners
-        window.removeEventListener('keydown', handleLetterKeyPress);        
+        window.removeEventListener('keydown', handleLetterKeyPress);
+        // Remove the visual indicator
+        removeViewportBoxIndicator();
     }
 
     keyboardMode.isActive = function() {

--- a/src/assets/js/keyboard-mode.js
+++ b/src/assets/js/keyboard-mode.js
@@ -212,7 +212,7 @@ function displayKeyboardModeMessage() {
     const message = document.getElementById("keyboard-mode-message");
     message.classList.remove("hidden");
     const innerMessage = document.createElement("div");
-    innerMessage.innerHTML = "<h2>Keyboard mode active! <span class='fa fa-keyboard'></span> </h2><p>Type a <kbd>letter</kbd> to select a country.<p><p>Move around with <kbd>&#8592;</kbd><kbd>&#8594;</kbd><kbd>&#8593;</kbd><kbd>&#8595;</kbd> keys.</p><p>Exit by zooming out with <kbd>-</kbd> key. </p><p>Toggle auditory feedback with <kbd>A</kbd> key.</p>";
+    innerMessage.innerHTML = "<h2>Keyboard mode active! <span class='fa fa-keyboard'></span> </h2><p>Type a <kbd>letter</kbd> to select a country.<p><p>Move around with <kbd>&#8592;</kbd><kbd>&#8594;</kbd><kbd>&#8593;</kbd><kbd>&#8595;</kbd> keys.</p><p>Exit by zooming out with <kbd>-</kbd> key. </p><p>Toggle audio feedback with <kbd>A</kbd> key.</p>";
     message.appendChild(innerMessage);
     
     // Add the visual indicator for the 400x400 box
@@ -358,7 +358,7 @@ function updateVisibleCountries(zoom) {
         
         // TODO: Find a working way to only announce this once
         if (!hasAnnounced) {
-            announcer.announce("Keyboard mode active! Press L to hear the list of countries.")
+            announcer.announce("Keyboard mode active! Press L to hear the list of countries. Press A to turn on audio feedback.")
             hasAnnounced = true;
         }
         

--- a/src/assets/js/keyboard-mode.js
+++ b/src/assets/js/keyboard-mode.js
@@ -8,8 +8,8 @@ const keyboardMode = keyboardMode || {};
 const MIN_ZOOM_LEVEL_FOR_KEYBOARD_MODE = 7;
 const MAX_COUNTRY_SUGGESTIONS = 20;
 let KEYBOARD_MODE_ACTIVE = false;
-// Exclude L and H because they are used for other purposes
-const ALPHABET = 'ABCDEFGIJKMNOPQRSTUVWXYZ'.split('');
+// Exclude A, L and H because they are used for other purposes
+const ALPHABET = 'BCDEFGIJKMNOPQRSTUVWXYZ'.split('');
 
 let visibleCountries = [];
 let keyBuffer = '';
@@ -602,6 +602,19 @@ function getAnnouncementText(baseText) {
                 map.dismissCenteredCountry();
             }
 
+            // Only handle arrow keys for navigation
+            if (e.key === 'ArrowUp' || e.key === 'ArrowDown' || 
+                e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+                
+                // Then trigger the auditory feedback after a small delay
+                // to allow the map to update first
+                setTimeout(function() {
+                    if (window.auditoryFeedback && window.auditoryFeedback.isEnabled()) {
+                        window.auditoryFeedback.updateFeedback();
+                    }
+                }, 100);
+            }
+
         });
 
     }
@@ -646,6 +659,11 @@ function getAnnouncementText(baseText) {
 
     keyboardMode.updateVisibleCountries = function(zoom) {
         updateVisibleCountries(zoom);
+    };
+
+    // Add this line to expose the getCurrentlyVisibleCountries function
+    keyboardMode.getCurrentlyVisibleCountries = function() {
+        return getCurrentlyVisibleCountries();
     };
 
 })();

--- a/src/assets/js/keyboard-mode.js
+++ b/src/assets/js/keyboard-mode.js
@@ -212,7 +212,7 @@ function displayKeyboardModeMessage() {
     const message = document.getElementById("keyboard-mode-message");
     message.classList.remove("hidden");
     const innerMessage = document.createElement("div");
-    innerMessage.innerHTML = "<h2>Keyboard mode active! <span class='fa fa-keyboard'></span> </h2><p>Type a <kbd>letter</kbd> to select a country.<p><p>Move around with <kbd>&#8592;</kbd><kbd>&#8594;</kbd><kbd>&#8593;</kbd><kbd>&#8595;</kbd> keys.</p><p>Exit by zooming out with <kbd>-</kbd> key. </p>";
+    innerMessage.innerHTML = "<h2>Keyboard mode active! <span class='fa fa-keyboard'></span> </h2><p>Type a <kbd>letter</kbd> to select a country.<p><p>Move around with <kbd>&#8592;</kbd><kbd>&#8594;</kbd><kbd>&#8593;</kbd><kbd>&#8595;</kbd> keys.</p><p>Exit by zooming out with <kbd>-</kbd> key. </p><p>Toggle auditory feedback with <kbd>A</kbd> key.</p>";
     message.appendChild(innerMessage);
   }
 

--- a/src/assets/js/keyboard-mode.js
+++ b/src/assets/js/keyboard-mode.js
@@ -266,6 +266,12 @@ function getVisibleCountries() {
     return filteredCountries;
 }
 
+// New function to get a summary of visible countries
+function getVisibleCountriesSummary() {
+    const countries = getVisibleCountries();
+    return `${countries.length} ${countries.length === 1 ? 'country' : 'countries'} visible, press L to list`;
+}
+
 function updateVisibleCountries(zoom) {
     keyboardMode.cleanup();
     
@@ -368,6 +374,14 @@ function assignLettersToCountries() {
     });
 }
 
+// Update the announcement functions to only include country count when keyboard mode is active
+function getAnnouncementText(baseText) {
+    if (KEYBOARD_MODE_ACTIVE) {
+        return `${baseText}. ${getVisibleCountriesSummary()}`;
+    }
+    return baseText;
+}
+
 (function () {
 
     keyboardMode.init = function (zoom, move, width, height, MAX_ZOOM) {
@@ -437,7 +451,12 @@ function assignLettersToCountries() {
                     e.preventDefault();
                     move(t, s, false, true);
                     getVisibleCountries();
-                    announcer.announce("Panning north", "assertive", 100)
+                    // Update announcement to include country count only when keyboard mode is active
+                    setTimeout(() => {
+                        const message = getAnnouncementText("Panning north");
+                        announcer.announce(message, "assertive", 100);
+                        console.log(message);
+                    }, 100);
                     ga('send', {
                         hitType: 'event',
                         eventCategory: 'Keyboard',
@@ -450,7 +469,12 @@ function assignLettersToCountries() {
                     e.preventDefault();
                     move(t, s, false, true);
                     getVisibleCountries();
-                    announcer.announce("Panning south", "assertive", 100)
+                    // Update announcement to include country count only when keyboard mode is active
+                    setTimeout(() => {
+                        const message = getAnnouncementText("Panning south");
+                        announcer.announce(message, "assertive", 100);
+                        console.log(message);
+                    }, 100);
                     ga('send', {
                         hitType: 'event',
                         eventCategory: 'Keyboard',
@@ -463,7 +487,12 @@ function assignLettersToCountries() {
                     e.preventDefault();
                     move(t, s, false, true);
                     getVisibleCountries();
-                    announcer.announce("Panning west", "assertive", 100)
+                    // Update announcement to include country count only when keyboard mode is active
+                    setTimeout(() => {
+                        const message = getAnnouncementText("Panning west");
+                        announcer.announce(message, "assertive", 100);
+                        console.log(message);
+                    }, 100);
                     ga('send', {
                         hitType: 'event',
                         eventCategory: 'Keyboard',
@@ -476,7 +505,12 @@ function assignLettersToCountries() {
                     e.preventDefault();
                     move(t, s, false, true);
                     getVisibleCountries();
-                    announcer.announce("Panning east", "assertive", 100)
+                    // Update announcement to include country count only when keyboard mode is active
+                    setTimeout(() => {
+                        const message = getAnnouncementText("Panning east");
+                        announcer.announce(message, "assertive", 100);
+                        console.log(message);
+                    }, 100);
                     ga('send', {
                         hitType: 'event',
                         eventCategory: 'Keyboard',
@@ -504,7 +538,13 @@ function assignLettersToCountries() {
                     move(t, s, false, true);
 
                     getVisibleCountries();
-                    announcer.announce(`Zoom ${e.key === '+' ? "in" : "out"} level ${parseInt(newScale)}`, "assertive", 100);
+                    // Update announcement to include country count only when keyboard mode is active
+                    setTimeout(() => {
+                        const baseMessage = `Zoom ${e.key === '+' ? "in" : "out"} level ${parseInt(newScale)}`;
+                        const message = getAnnouncementText(baseMessage);
+                        announcer.announce(message, "assertive", 100);
+                        console.log(message);
+                    }, 100);
                     ga('send', {
                         hitType: 'event',
                         eventCategory: 'Keyboard',
@@ -534,9 +574,14 @@ function assignLettersToCountries() {
                         });
                         return;
                     }
-                    // announce the list of countries
-                    let message = "List of countries: ";
+                    // announce the list of countries. Temporarily removing the prefix to improve screen reader ux
+                    // let message = "Listing countries: ";
+                    let message = "";
                     const countries = getCurrentlyVisibleCountries();
+                    
+                    // Sort countries by their assigned letter
+                    countries.sort((a, b) => a.number.localeCompare(b.number));
+                    
                     countries.forEach((country) => {
                         message += `${country.number}: ${country.name} (${country.artistCount} artists), `;
                     });

--- a/src/assets/js/keyboard-mode.js
+++ b/src/assets/js/keyboard-mode.js
@@ -8,7 +8,8 @@ const keyboardMode = keyboardMode || {};
 const MIN_ZOOM_LEVEL_FOR_KEYBOARD_MODE = 7;
 const MAX_COUNTRY_SUGGESTIONS = 20;
 let KEYBOARD_MODE_ACTIVE = false;
-const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+// Exclude L and H because they are used for other purposes
+const ALPHABET = 'ABCDEFGIJKMNOPQRSTUVWXYZ'.split('');
 
 let visibleCountries = [];
 let keyBuffer = '';

--- a/src/assets/js/map.js
+++ b/src/assets/js/map.js
@@ -507,6 +507,8 @@ map.COUNTRY_BBOX_OVERRIDES = COUNTRY_BBOX_OVERRIDES;
             removeArtistDiv();
             // zoom out map, fulhack
             clicked(centered);
+            // Restore focus to the img
+            d3.select('#map-svg').node().focus();
           }) //"stäng" onclick slutar
       }) // on click slutar
 

--- a/src/assets/js/map.js
+++ b/src/assets/js/map.js
@@ -590,6 +590,8 @@ map.COUNTRY_BBOX_OVERRIDES = COUNTRY_BBOX_OVERRIDES;
 
     //adjust the country hover stroke width based on zoom level
     d3.selectAll(".country").style("stroke-width", 1.5 / s);
+
+    window.triggerAuditoryFeedback();
   }
   map.move = move;
 
@@ -1395,5 +1397,29 @@ function getCountryCenter(countryTopoData) {
             break;
     }
   }
+
+  // Update the setupAuditoryFeedbackForMap function to only trigger on keyboard navigation
+  function setupAuditoryFeedbackForMap() {
+    // Remove the automatic triggers on zoom/pan
+    
+    // Only trigger feedback when new data is loaded
+    document.addEventListener("artistsLoaded", function() {
+      if (window.auditoryFeedback) {
+        window.auditoryFeedback.updateFeedback();
+      }
+    });
+    
+    // Create a custom event dispatcher to trigger feedback manually if needed
+    window.triggerAuditoryFeedback = function() {
+      if (window.auditoryFeedback) {
+        window.auditoryFeedback.updateFeedback();
+      }
+    };
+    
+    // Remove the automatic trigger in the move function
+  }
+
+  // Call this after your map is initialized
+  setupAuditoryFeedbackForMap();
 
 })(window, document)

--- a/src/assets/js/map.js
+++ b/src/assets/js/map.js
@@ -1422,4 +1422,9 @@ function getCountryCenter(countryTopoData) {
   // Call this after your map is initialized
   setupAuditoryFeedbackForMap();
 
+  // Add this to the public API section at the bottom of the file
+  map.getColorDomain = function() {
+    return mydomain; // This is the array that defines the color thresholds
+  };
+
 })(window, document)

--- a/src/assets/scss/themes/_default.scss
+++ b/src/assets/scss/themes/_default.scss
@@ -127,17 +127,23 @@ kbd {
     font-size: 0.9rem;
     padding: 2px 4px;
     font-size: 0.85em;
-    color: #555;
-    background-color: #fcfcfc;
-    border: solid 1px #ccc;
+    color: #fff;
+    background-color: #333;
+    border: solid 1px #666;
     border-radius: 3px;
-    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #ffffff inset;
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.2), 0 0 0 2px #222 inset;
     white-space: nowrap;
     kbd+& {
         margin-left: 4px;
     }
 }
 
+body.dark kbd {
+    color: #222;
+    background-color: #fcfcfc;
+    border: solid 1px #ccc;
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #ffffff inset;
+}
 
 /*
  * Tooltip

--- a/src/assets/scss/themes/_default.scss
+++ b/src/assets/scss/themes/_default.scss
@@ -210,3 +210,7 @@ body.green_black #progress-text:after {
         border-color: white;
     }
 }
+
+#viewport-box-indicator {
+  // No animation needed
+}

--- a/src/index.html
+++ b/src/index.html
@@ -146,10 +146,12 @@
 							<dd>Zoom out</dd>
 							<dt><kbd>L</kbd></dt>
 							<dd>Read out all visible countries (for screen readers)</dd>
-							<dt>Letters <kbd>A</kbd> to <kbd>Z</kbd> (excluding <kbd>L</kbd> and <kbd>H</kbd>)</dt>
+							<dt>Letters <kbd>B</kbd> to <kbd>Z</kbd> (excluding <kbd>L</kbd> and <kbd>H</kbd>)</dt>
 							<dd>Choose a country</dd>
 							<dt><kbd>H</kbd></dt>
 							<dd>Read out help (for screen readers)</dd>
+							<dt><kbd>A</kbd></dt>
+							<dd>Toggle auditory feedback</dd>
 						</dl>
 						<h2>Other accessibility features</h2>
 						<em>Reduced animations</em>
@@ -198,7 +200,8 @@
 							<p>You can search directly for a country or an artist with the shortcut CTRL + F.</p>
 						</li>
 						<li>
-							<p>Or you can pan and zoom the map with the arrows and plus and minus keys. When you zoom in far enough, you can list all visible countries by pressing L. Then select a country by pressing the listed letter key. For instance, pressing "C" for Sweden.</p>
+							<p>Or you can pan and zoom the map with the arrows and plus and minus keys. When you zoom in far enough, you can list all visible countries by pressing L. Then select a country by pressing the listed letter key.</p>
+							<p>An audio tone will play when you navigate with the keyboard. Higher pitch means more artists among the countries in the current view, lower pitch means less. Press A to disable the tone.</p>
 							<p>You may need to activate forms mode.</p>
 						</li>
 					</ul>


### PR DESCRIPTION
Adds an optional audio feedback tone for keyboard navigation (off by default, turn on by pressing "A" key)

The density of the currently visible countries is translated into a pitch, making it possible to "hear" the map colors. 