### PR TITLE
fix close button assignment not working on artifical click event

### DIFF
--- a/src/assets/js/map.js
+++ b/src/assets/js/map.js
@@ -512,9 +512,10 @@ window.addEventListener('wheel', function() { window.lastInputWasKeyboard = fals
             id = d.id;
           };
         })
-        var mouse = d3.mouse(svg.node()).map(function(d) {
-          return parseInt(d);
-        });
+
+        var mouse = d3.event && d3.event.clientX !== undefined
+          ? d3.mouse(svg.node()).map(function(d) { return parseInt(d); })
+          : [0, 0];
 
         closeButton
           .on("click", function(d, i) {


### PR DESCRIPTION
when selecting the country from the country list, the click event is artificially created
therefore there is no mouse position and d3.mouse(svg.node()) throws errors which causes the close button to not get assigned its closing function

this is fixed by only calling it if there is a mouse position and otherwise assigning values ([0, 0])